### PR TITLE
Change NATIVE_ARCH to CURRENT_ARCH

### DIFF
--- a/envcov.sh
+++ b/envcov.sh
@@ -10,4 +10,4 @@ source env.sh
 LCOV_INFO=Coverage.info
 
 LCOV_PATH=${SRCROOT}/XcodeCoverage/lcov-1.10/bin
-OBJ_DIR=${OBJECT_FILE_DIR_normal}/${NATIVE_ARCH}
+OBJ_DIR=${OBJECT_FILE_DIR_normal}/${CURRENT_ARCH}

--- a/exportenv.sh
+++ b/exportenv.sh
@@ -4,4 +4,4 @@
 #   Source: https://github.com/jonreid/XcodeCoverage
 #
 
-export | egrep '( BUILT_PRODUCTS_DIR)|(NATIVE_ARCH=)|(OBJECT_FILE_DIR_normal)|(SRCROOT)|(OBJROOT)' > XcodeCoverage/env.sh
+export | egrep '( BUILT_PRODUCTS_DIR)|(CURRENT_ARCH)|(OBJECT_FILE_DIR_normal)|(SRCROOT)|(OBJROOT)' > XcodeCoverage/env.sh


### PR DESCRIPTION
If you use NATIVE_ARCH you get some problems. I get i386 even though it should be x86_64. You should use CURRENT_ARCH. I found this discussion on the apple list : http://lists.apple.com/archives/xcode-users/2011/Jul/msg00086.html. 
