### PR TITLE
Fix passing list of arguments to lcov and gcov

### DIFF
--- a/envcov.sh
+++ b/envcov.sh
@@ -16,5 +16,5 @@ OBJ_DIR=${OBJECT_FILE_DIR_normal}/${CURRENT_ARCH}
 
 # Fix for the new LLVM-COV that requires gcov to have a -v paramter
 LCOV() {
-	${LCOV_PATH}/lcov $* --gcov-tool ${XCODECOVERAGE_PATH}/llvm-cov-wrapper.sh
+	${LCOV_PATH}/lcov "$@" --gcov-tool ${XCODECOVERAGE_PATH}/llvm-cov-wrapper.sh
 }

--- a/llvm-cov-wrapper.sh
+++ b/llvm-cov-wrapper.sh
@@ -9,5 +9,5 @@ if [ "$1" = "-v" ]; then
     echo "llvm-cov-wrapper 4.2.1"
     exit 0
 else
-    /usr/bin/gcov $*
+    /usr/bin/gcov "$@"
 fi


### PR DESCRIPTION
Without proper quoting, coverage scripts would fail if the built products directory contains a space.
