### PR TITLE
Exculde `Developer/SDKs` instead of `Applications/Xcode.app`

### DIFF
--- a/getcov
+++ b/getcov
@@ -31,7 +31,7 @@ gather_coverage()
 
 exclude_data()
 {
-    LCOV --remove ${LCOV_INFO} "Applications/Xcode.app/*" -d "${OBJ_DIR}" -o ${LCOV_INFO}
+    LCOV --remove ${LCOV_INFO} "Developer/SDKs/*" -d "${OBJ_DIR}" -o ${LCOV_INFO}
     LCOV --remove ${LCOV_INFO} "main.m" -d "${OBJ_DIR}" -o ${LCOV_INFO}
     # Remove other patterns here...
 }


### PR DESCRIPTION
So that exclusion works for any Xcode version, even if is renamed e.g. Xcode6-Beta2.app
